### PR TITLE
Fix missing = sign to set replication factor

### DIFF
--- a/templates/server.properties.erb
+++ b/templates/server.properties.erb
@@ -48,7 +48,7 @@ num.partitions=<%= Array(@log_dirs).length %>
 
 # The default replication factor for automatically created topics.
 # Default to the number of brokers in this cluster.
-default.replication.factor<%= @brokers.keys.length %>
+default.replication.factor=<%= @brokers.keys.length %>
 
 # Enable auto creation of topic on the server. If this is set to true
 # then attempts to produce, consume, or fetch metadata for a non-existent


### PR DESCRIPTION
Was seeing this in the Kafka logs:

`WARN Property default.replication.factor4 is not valid (kafka.utils.VerifiableProperties)`

Looks like it's because this template is missing a `=`
