### PR TITLE
Add mirror consumer creation via class parameter and hiera

### DIFF
--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -14,6 +14,7 @@ class kafka::defaults {
             'id'   => 1,
         },
     }
+    $consumers = {}
 
     $zookeeper_hosts                     = ['localhost:2181']
     $zookeeper_connection_timeout_ms     = 6000

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -71,7 +71,7 @@ class kafka::mirror(
     }
 
     # Automatically create consumers if provided
-    if (size($consumers) > 0) {
+    if (size(keys($consumers)) > 0) {
         create_resources('kafka::mirror::consumer', $consumers)
     }
 

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -10,12 +10,16 @@
 #                               should be of the form:
 #                               { 'hostA' => { 'id' => 1, 'port' => 12345 }, 'hostB' => { 'id' => 2 }, ... }
 #                               'port' is optional, and will default to 9092.
+# $consumers                  - Hash of Kafka consumers for automatic kafka::mirror::consumer creation:
+#                               { 'consumerNameA' => { 'zookeeper_hosts' => [ 'host1' ]},
+#                                 'consumerNameB' => { 'zookeeper_hosts' => [ 'host2' ]}, ... }
 
 # $jmx_port                    - Port on which to expose JMX metrics.  Default: 9999
 #
 class kafka::mirror(
     $enabled                               = true,
     $destination_brokers                   = $kafka::defaults::brokers,
+    $consumers                             = $kafka::defaults::consumers,
 
     $jmx_port                              = $kafka::defaults::jmx_port,
 
@@ -64,6 +68,11 @@ class kafka::mirror(
     file { '/etc/kafka/mirror':
         ensure => 'directory',
         require => Package['kafka-mirror'],
+    }
+
+    # Automatically create consumers if provided
+    if (size($consumers) > 0) {
+        create_resources('kafka::mirror::consumer', $consumers)
     }
 
     # MirrorMaker will produce to this cluster


### PR DESCRIPTION
Please note this introduces a dependency on `puppetlabs/stdlib` for the `size` function. I can submit a metadata.json if you'd like.

Consumer configuration is now simply (via hiera YAML):

```
kafka::mirror::consumers:
  consumerNameA:
    consumer_group_id: consumerGroupA
    zookeeper_hosts:
      - zkA.example.com:2181
  consumerNameB:
    consumer_group_id: consumerGroupB
    zookeeper_hosts:
      - zkB.example.com:2181
```
